### PR TITLE
fix(ci): add staging branch to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, staging ]
   pull_request:
-    branches: [ main, develop, 'release/*', 'v[0-9]*.[0-9]*' ]
+    branches: [ main, develop, staging, 'release/*', 'v[0-9]*.[0-9]*' ]
 
 jobs:
   lint:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Security Analysis"
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "develop", "staging" ]
   pull_request:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "develop", "staging" ]
   schedule:
     # Run security scan weekly on Monday at 3am UTC
     - cron: '0 3 * * 1'


### PR DESCRIPTION
## 🐛 Hotfix: Enable CI for Staging Branch

### Problem
CI checks are not running for PRs targeting the staging branch, causing PR #11 to be stuck.

### Solution
- Added `staging` to CI workflow triggers
- Added `staging` to CodeQL workflow triggers

### Impact
- CI will now run for all staging-related changes
- PR #11 can proceed once this is merged

### Testing
After this is merged, we may need to close and reopen PR #11 to trigger the CI checks.

This is a critical fix to unblock the branch synchronization process.