### PR TITLE
fix: update domain from zopio.io to zopio.dev

### DIFF
--- a/.github/DISCUSSIONS.md
+++ b/.github/DISCUSSIONS.md
@@ -81,7 +81,7 @@ Active and helpful community members may receive:
 
 - [Contributing Guide](/.github/CONTRIBUTING.md)
 - [Code of Conduct](/.github/CODE_OF_CONDUCT.md)
-- [Documentation](https://docs.zopio.io)
+- [Documentation](https://docs.zopio.dev)
 - [Issue Tracker](https://github.com/zopiolabs/zopio/issues)
 
 ## 💡 Tips for Great Discussions

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,4 +2,4 @@
 
 github: [zopiolabs]
 open_collective: zopio
-custom: ["https://zopio.io/sponsor", "https://zopio.io/support"]
+custom: ["https://zopio.dev/sponsor", "https://zopio.dev/support"]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,10 +4,10 @@ contact_links:
     url: https://github.com/zopiolabs/zopio/discussions
     about: Ask questions and discuss ideas with the community
   - name: 📖 Documentation
-    url: https://docs.zopio.io
+    url: https://docs.zopio.dev
     about: Check our documentation for guides and API references
   - name: 💼 Professional Support
-    url: https://zopio.io/support
+    url: https://zopio.dev/support
     about: Get professional support for enterprise deployments
   - name: 🛡️ Security Issues
     url: https://github.com/zopiolabs/zopio/security/policy

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -30,7 +30,7 @@ body:
     attributes:
       label: Documentation Location
       description: Where is the documentation located? (URL or file path)
-      placeholder: "e.g., /docs/getting-started.md or https://docs.zopio.io/..."
+      placeholder: "e.g., /docs/getting-started.md or https://docs.zopio.dev/..."
 
   - type: textarea
     id: issue-description

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for your interest in Zopio! Before asking your question:
-        - 📖 Check our [documentation](https://docs.zopio.io)
+        - 📖 Check our [documentation](https://docs.zopio.dev)
         - 🔍 Search [existing issues](https://github.com/zopiolabs/zopio/issues)
         - 💬 Consider using [GitHub Discussions](https://github.com/zopiolabs/zopio/discussions) for general questions
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -14,8 +14,8 @@ The Zopio team takes security seriously. We appreciate your efforts to responsib
    - Fill out the form with details
 
 2. **Email**:
-   - Send details to: security@zopio.io
-   - Encrypt sensitive information using our [PGP key](https://keys.openpgp.org/search?q=security@zopio.io)
+   - Send details to: security@zopio.dev
+   - Encrypt sensitive information using our [PGP key](https://keys.openpgp.org/search?q=security@zopio.dev)
 
 ### What to Include
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,7 +26,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           git-message: 'chore(release): update CHANGELOG.md for {version}'
           git-user-name: 'zopio-bot'
-          git-user-email: 'bot@zopio.io'
+          git-user-email: 'bot@zopio.dev'
           preset: 'angular'
           tag-prefix: 'v'
           output-file: 'CHANGELOG.md'

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -356,7 +356,7 @@ git reset --hard HEAD~1
 
 - 💬 [GitHub Discussions](https://github.com/zopiolabs/zopio/discussions)
 - 🐛 [Issue Tracker](https://github.com/zopiolabs/zopio/issues)
-- 📧 [Email Support](mailto:support@zopio.io)
+- 📧 [Email Support](mailto:support@zopio.dev)
 
 ---
 


### PR DESCRIPTION
## Summary

This PR updates all domain references from `zopio.io` to `zopio.dev` to ensure consistency across the project.

## Changes

- Updated documentation URLs from `docs.zopio.io` to `docs.zopio.dev`
- Updated email addresses from `@zopio.io` to `@zopio.dev`
- Updated support and sponsor URLs to use the correct domain
- Fixed all references in:
  - Issue templates
  - Security policy
  - Funding configuration
  - Workflow documentation
  - GitHub Actions workflows
  - Discussions guidelines

## Testing

All changes are documentation and configuration updates - no code changes that require testing.

## Related Issues

Ensures domain consistency across the repository.