### PR TITLE
fix(ci): resolve CI workflow artifact issue blocking PR merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,19 @@ jobs:
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
       
-  lint:
+    # Create artifact of node_modules for other jobs
+    - name: Create node_modules artifact
+      run: tar -czf node_modules.tar.gz node_modules
+      
+    # Upload the artifact for use in other jobs
+    - name: Upload node_modules artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: node_modules
+        path: node_modules.tar.gz
+        retention-days: 1
+      
+  Lint:
     name: Lint
     runs-on: ubuntu-latest
     needs: setup  # Depends on setup job completion
@@ -76,11 +88,17 @@ jobs:
     - name: Extract node_modules
       run: tar -xzf node_modules.tar.gz
       
+    - name: Install dependencies (fallback)
+      run: |
+        if [ ! -d "node_modules" ]; then
+          pnpm install --frozen-lockfile
+        fi
+      
     # Run Biome linter via ultracite, gracefully handle if script doesn't exist
     - name: Run linter
       run: pnpm lint || echo "Linting passed (no lint script found)"
       
-  test:
+  Test:
     name: Test
     runs-on: ubuntu-latest
     needs: setup  # Depends on setup job completion
@@ -105,11 +123,17 @@ jobs:
     - name: Extract node_modules
       run: tar -xzf node_modules.tar.gz
       
+    - name: Install dependencies (fallback)
+      run: |
+        if [ ! -d "node_modules" ]; then
+          pnpm install --frozen-lockfile
+        fi
+      
     # Run Vitest test suite, gracefully handle if script doesn't exist
     - name: Run tests
       run: pnpm test || echo "Tests passed (no test script found)"
       
-  build:
+  Build:
     name: Build
     runs-on: ubuntu-latest
     needs: setup  # Depends on setup job completion
@@ -133,6 +157,12 @@ jobs:
         
     - name: Extract node_modules
       run: tar -xzf node_modules.tar.gz
+      
+    - name: Install dependencies (fallback)
+      run: |
+        if [ ! -d "node_modules" ]; then
+          pnpm install --frozen-lockfile
+        fi
       
     # Build all packages in the monorepo, gracefully handle if script doesn't exist
     - name: Build project


### PR DESCRIPTION
## Description

This PR fixes the CI workflow issue that's preventing PRs from being merged to protected branches.

### The Problem
- The `setup` job wasn't creating the `node_modules` artifact that other jobs expected
- Job IDs didn't match the exact names required by branch protection rules
- This caused all CI checks to fail silently, blocking PR merges

### The Solution
1. **Fixed artifact creation**: Added steps to create and upload the `node_modules` artifact
2. **Added fallback installation**: Jobs now have fallback dependency installation
3. **Updated job IDs**: Changed from lowercase to match branch protection requirements exactly

### Important Note
This PR must be merged to `main` first (not `develop`) so the workflow is available to all branches.

### Impact
Once merged to main:
- CI checks will run properly on all PRs
- PR #37 can be unblocked by pushing an empty commit to trigger the workflow
- All future PRs will have working CI checks

Fixes the issue blocking PR #37