### PR TITLE
fix(ci): remove inline comments from semantic PR validation config

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -15,6 +15,45 @@
 #   - Breaking changes marked with ! must have documentation
 #   - Subject must not start with uppercase
 #
+# Type Definitions:
+#   - feat: New features
+#   - fix: Bug fixes
+#   - docs: Documentation only changes
+#   - style: Code style changes (formatting, etc.)
+#   - refactor: Code changes that neither fix bugs nor add features
+#   - perf: Performance improvements
+#   - test: Adding or updating tests
+#   - build: Build system or dependency changes
+#   - ci: CI/CD configuration changes
+#   - chore: Other changes that don't modify src or test files
+#   - revert: Reverts a previous commit
+#
+# Scope Definitions:
+#   - api: API application
+#   - app: Main application
+#   - auth: Authentication packages
+#   - build: Build configuration
+#   - ci: CI/CD workflows
+#   - cli: CLI tool
+#   - core: Core utilities
+#   - crud: CRUD framework
+#   - data: Data providers
+#   - database: Database schema/config
+#   - deps: Dependencies
+#   - design-system: UI component library
+#   - docs: Documentation app
+#   - email: Email templates
+#   - i18n: Internationalization
+#   - infra: Infrastructure
+#   - monitoring: Monitoring/logging
+#   - payments: Payment processing
+#   - security: Security features
+#   - studio: Studio app
+#   - tests: Test infrastructure
+#   - ui: UI components
+#   - web: Marketing website
+#   - workspace: Monorepo configuration
+#
 # Security Note:
 #   Uses pull_request_target for write permissions on PRs from forks
 
@@ -39,43 +78,43 @@ jobs:
         with:
           # Allowed commit types from conventional commits spec
           types: |
-            feat        # New features
-            fix         # Bug fixes
-            docs        # Documentation only changes
-            style       # Code style changes (formatting, etc.)
-            refactor    # Code changes that neither fix bugs nor add features
-            perf        # Performance improvements
-            test        # Adding or updating tests
-            build       # Build system or dependency changes
-            ci          # CI/CD configuration changes
-            chore       # Other changes that don't modify src or test files
-            revert      # Reverts a previous commit
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
           # Allowed scopes - typically align with package/app names
           scopes: |
-            api             # API application
-            app             # Main application
-            auth            # Authentication packages
-            build           # Build configuration
-            ci              # CI/CD workflows
-            cli             # CLI tool
-            core            # Core utilities
-            crud            # CRUD framework
-            data            # Data providers
-            database        # Database schema/config
-            deps            # Dependencies
-            design-system   # UI component library
-            docs            # Documentation app
-            email           # Email templates
-            i18n            # Internationalization
-            infra           # Infrastructure
-            monitoring      # Monitoring/logging
-            payments        # Payment processing
-            security        # Security features
-            studio          # Studio app
-            tests           # Test infrastructure
-            ui              # UI components
-            web             # Marketing website
-            workspace       # Monorepo configuration
+            api
+            app
+            auth
+            build
+            ci
+            cli
+            core
+            crud
+            data
+            database
+            deps
+            design-system
+            docs
+            email
+            i18n
+            infra
+            monitoring
+            payments
+            security
+            studio
+            tests
+            ui
+            web
+            workspace
           # Scope is optional but recommended
           requireScope: false
           # Only validate PR title, not individual commits


### PR DESCRIPTION
## Summary
Fixes the semantic PR validation workflow that was causing all PRs to fail validation.

## Problem
The workflow was failing with syntax errors when parsing the types and scopes configuration. This was blocking PR #41 and potentially all other PRs.

## Solution
- Removed all inline comments from the types and scopes lists
- Moved the documentation to the workflow header
- Kept the configuration clean and parseable

## Testing
- This PR itself uses the fix(ci): format which should now be recognized as valid
- Once merged, PR #41 should pass semantic validation

Fixes the semantic PR validation blocking PR #41