### PR TITLE
Test: Invalid branch name - wip/dashboard

### DIFF
--- a/test-branch-validation-4.txt
+++ b/test-branch-validation-4.txt
@@ -1,0 +1,2 @@
+Test file for branch naming validation - feat
+This branch should fail validation due to: no suffix after slash

--- a/test-branch-validation-6.txt
+++ b/test-branch-validation-6.txt
@@ -1,0 +1,2 @@
+Test file for branch naming validation - wip/dashboard
+This branch should fail validation due to: invalid prefix 'wip'


### PR DESCRIPTION
Testing branch naming validation: invalid prefix 'wip'