### PR TITLE
chore(sync): merge main into staging - Semgrep fix

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -109,25 +109,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'pnpm'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10.11.0
-          
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       # Install dependencies for better type inference
       - name: Install dependencies


### PR DESCRIPTION
## Summary
Syncing main branch changes to staging, including the critical Semgrep workflow fix.

## Changes from main
- 🔧 fix: remove redundant pnpm caching in security workflow (#104)
- 🔧 fix: test release workflow trigger (#98)
- 🔄 chore(sync): merge develop into staging (#96) (#97)

## Key Fix
The Semgrep SAST scanner in the security workflow was failing due to incorrect pnpm setup order. This has been fixed by removing the caching configuration and simplifying the workflow.

## Impact
- Security workflow will now run successfully
- PR merges will no longer be blocked by Semgrep failures
- Staging environment will have the latest fixes from production

## Git Flow
Following standard git flow: main → staging → develop