### PR TITLE
chore(sync): merge staging into develop - Semgrep fix

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -109,25 +109,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'pnpm'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10.11.0
-          
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       # Install dependencies for better type inference
       - name: Install dependencies


### PR DESCRIPTION
## Summary
Syncing staging branch changes to develop, including the critical Semgrep workflow fix.

## Changes from staging
- 🔧 fix: remove redundant pnpm caching in security workflow
- All changes that were synced from main to staging

## Key Fix
The Semgrep SAST scanner in the security workflow was failing due to incorrect pnpm setup order. This has been fixed by removing the caching configuration and simplifying the workflow.

## Impact
- Security workflow will now run successfully
- PR merges will no longer be blocked by Semgrep failures
- Develop environment will have the latest fixes from production and staging

## Git Flow
Following standard git flow: main → staging → develop