### PR TITLE
fix(ci): resolve Security workflow failure by fixing Semgrep configuration

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -130,7 +130,6 @@ jobs:
             p/nextjs           # Next.js-specific issues
             p/security-audit   # General security rules
             p/owasp-top-ten   # OWASP Top 10 vulnerabilities
-          generateSarif: true   # Generate SARIF output
 
       # Upload results even if scan finds issues
       - name: Upload Semgrep results


### PR DESCRIPTION
## Summary
- Fixes the Security Scan workflow failure by removing invalid `generateSarif` parameter from Semgrep action

## Problem
The Security workflow has been failing because the Semgrep action was configured with an invalid parameter:
- `generateSarif: true` is not a valid input for the `returntocorp/semgrep-action@v1`
- This was causing all Security scans to fail

## Solution
- Removed the invalid `generateSarif` parameter
- The Semgrep action will still generate SARIF output by default
- The upload-sarif step remains unchanged

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Security workflow runs successfully
- [ ] Semgrep scan completes without errors
- [ ] SARIF results are properly uploaded

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] Tests pass locally
- [x] Conventional commits used