### PR TITLE
hotfix: remove deprecated Semgrep SAST and fix staging branch trigger

### DIFF
--- a/.github/git-flow-diagram.md
+++ b/.github/git-flow-diagram.md
@@ -228,7 +228,6 @@ flowchart LR
         CQL[CodeQL<br/>Analysis]
         Trivy[Dependency<br/>Scan]
         Secret[TruffleHog<br/>Secret Scan]
-        SAST[Semgrep<br/>SAST]
     end
     
     subgraph "Automation"
@@ -249,7 +248,7 @@ flowchart LR
     BN & SP & PS --> CI{CI Pipeline}
     CI --> Lint & Test & Build & Type
     CI --> CQL
-    CI -->|main/develop only| Trivy & Secret & SAST
+    CI -->|main/develop only| Trivy & Secret
     
     PR --> Label & Assign & Welcome
     
@@ -258,7 +257,7 @@ flowchart LR
     
     Schedule[Scheduled Jobs] --> Stale
     WeeklySchedule[Weekly Schedule] --> CQL
-    DailySchedule[Daily Schedule] --> Trivy & Secret & SAST
+    DailySchedule[Daily Schedule] --> Trivy & Secret
     
     classDef protection fill:#FFE5B4,stroke:#333,stroke-width:2px
     classDef quality fill:#B4E5FF,stroke:#333,stroke-width:2px
@@ -268,7 +267,7 @@ flowchart LR
     
     class BN,SP,PS protection
     class Lint,Test,Build,Type quality
-    class CQL,Trivy,Secret,SAST security
+    class CQL,Trivy,Secret security
     class Label,Assign,Welcome,Stale automation
     class CL,Ver,Pub,GH release
     class Schedule,WeeklySchedule,DailySchedule automation
@@ -550,7 +549,6 @@ git push origin hotfix/critical-bug
 ✓ CodeQL analysis
 ✓ Trivy dependency scan
 ✓ TruffleHog secrets
-✓ Semgrep SAST
 ✓ Code quality checks
 ```
 
@@ -1069,7 +1067,6 @@ Response: Within 48 hours
 | **🔵 CodeQL** | SAST | PR + Weekly | JavaScript/TypeScript vulnerabilities |
 | **🐳 Trivy** | Dependencies | PR + Daily | Known CVEs in dependencies |
 | **🐗 TruffleHog** | Secrets | On PR | Exposed credentials, API keys |
-| **🌱 Semgrep** | SAST | On PR | OWASP Top 10, security patterns |
 | **🤖 Dependabot** | Updates | Weekly | Outdated dependencies |
 
 </details>

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,8 +11,7 @@
 # Scan Types:
 #   1. Dependency vulnerabilities (Trivy)
 #   2. Secret detection (TruffleHog)
-#   3. Static Application Security Testing (Semgrep)
-#   4. Container security (when applicable)
+#   3. Container security (when applicable)
 #
 # Results:
 #   - Uploaded to GitHub Security tab
@@ -23,7 +22,7 @@ name: Security Scan
 
 on:
   push:
-    branches: [main, develop, staging]
+    branches: [main, develop]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
@@ -97,46 +96,6 @@ jobs:
           head: HEAD                                       # Current commit
           extra_args: --only-verified                      # Only report verified secrets
 
-  sast-scan:
-    name: Static Application Security Testing
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      # Setup environment for accurate SAST analysis
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.11.0
-
-      # Install dependencies for better type inference
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      # Run static analysis for security issues
-      - name: Run Semgrep
-        uses: returntocorp/semgrep-action@v1
-        with:
-          config: >-
-            p/javascript        # JavaScript-specific rules
-            p/typescript        # TypeScript-specific rules
-            p/react            # React security patterns
-            p/nextjs           # Next.js-specific issues
-            p/security-audit   # General security rules
-            p/owasp-top-ten   # OWASP Top 10 vulnerabilities
-
-      # Upload results even if scan finds issues
-      - name: Upload Semgrep results
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
-        with:
-          sarif_file: semgrep.sarif
 
   docker-scan:
     name: Container Security Scan


### PR DESCRIPTION
## Summary
Emergency hotfix to remove deprecated Semgrep SAST scanner and fix incorrect staging branch trigger.

## Changes
- Removed entire sast-scan job using deprecated returntocorp/semgrep-action@v1
- Fixed incorrect staging branch trigger (should not trigger on push to staging per git-flow-diagram.md)
- Updated git-flow-diagram.md to remove all Semgrep references
- Security scanning now relies on CodeQL for SAST coverage

## Why This Is a Hotfix
1. Semgrep action is deprecated and causing workflow failures
2. Security workflow incorrectly triggers on staging branch (violates git-flow)
3. These issues affect production workflows

## Testing
- Workflow syntax validated
- Remaining security scans (Trivy, TruffleHog, Docker) continue to function
- CodeQL provides SAST coverage

BREAKING CHANGE: Semgrep SAST scanning has been removed. Projects relying on Semgrep-specific security checks should ensure CodeQL rules cover their requirements.