### PR TITLE
test: PR to develop - should NOT trigger build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@
 #
 # Purpose: Comprehensive build, lint, typecheck, and test pipeline for pull requests
 #          targeting the main branch. Ensures code quality and catches issues early.
+# TEST: Git flow validation test
 #
 # Triggers:
 #   - Pull requests to main branch (opened, synchronized, or reopened)


### PR DESCRIPTION
## Test Scenario: PR to develop branch

This PR tests that build.yml workflow does NOT trigger for PRs targeting the develop branch.

### Expected Behavior:
- ❌ build.yml should NOT run (it only runs for PRs to main)
- ✅ ci.yml should run (it runs for PRs to develop)
- ✅ pr-validation.yml should run

### Git Flow Compliance:
According to git-flow-diagram.md:
- Build workflow with bundle analysis only runs for PRs to main branch
- This PR targets develop, so build.yml should be skipped

### Test Type: Success Scenario
This is testing the expected behavior where build.yml correctly ignores PRs to develop.