### PR TITLE
test: PR assignment workflow - skip when already assigned

### DIFF
--- a/test-pr-assignment.md
+++ b/test-pr-assignment.md
@@ -1,0 +1,11 @@
+# PR Assignment Test File
+
+This file is used to test the automatic PR assignment workflow.
+
+## Test Case 1: Basic PR Author Assignment
+- Created on branch: test/git-flow-validation-20250624-190740
+- Purpose: Test that PR is automatically assigned to its author
+- Expected: PR should be assigned to umutcanoner
+
+## Test Timestamp
+- Created: 2025-06-24 19:07:40

--- a/test-pr-assignment.md
+++ b/test-pr-assignment.md
@@ -9,3 +9,7 @@ This file is used to test the automatic PR assignment workflow.
 
 ## Test Timestamp
 - Created: 2025-06-24 19:07:40
+- Updated: 2025-06-24 19:09:00
+
+## Test Case 2: Skip Assignment
+- Testing behavior when PR already has assignees


### PR DESCRIPTION
## Test Case 2: Skip Assignment When Already Assigned

This PR tests that the workflow skips assignment when PR already has assignees.

### Expected Behavior
- PR should NOT be reassigned (already has assignee)
- Workflow should detect existing assignee and skip

### Test Setup
- PR created with manual assignee: @mkzopio

### Workflow Being Tested
- .github/workflows/pr-assignment.yml

---
*This is an automated test PR for validating GitHub workflows*